### PR TITLE
convert to tibble which dplyr no longer does automatically.

### DIFF
--- a/R/file_urls.R
+++ b/R/file_urls.R
@@ -107,7 +107,7 @@ fetch_file_urls <- function () {
     })
 
     # combine the new data with any existing data
-    values <- rbind(values, result)
+    values <- rbind(tibble::as_tibble(values), result)
 
     # update the URL to the next page (or NULL if this is the last page)
     page_url <- json$links[["next"]]


### PR DESCRIPTION
It looks from the tests that you expect a tibble, but with the upcoming release of `dplyr` you'd get a `data.frame`. Alternatively this could be a change in the test: 

```r
test_that("return value of get_file_urls is a tibble", {
  expect_is(get_file_urls(), "tbl_df")
})
```

We plan on releasing dplyr 1.0.1 this week. 